### PR TITLE
Implement Array#flatten(depth)

### DIFF
--- a/lib/rumonade/array.rb
+++ b/lib/rumonade/array.rb
@@ -18,7 +18,10 @@ module Rumonade
       METHODS_TO_REPLACE_WITH_MONAD = Monad::DEFAULT_METHODS_TO_REPLACE_WITH_MONAD - [:map]
 
       def bind(lam = nil, &blk)
-        inject(self.class.empty) { |arr, elt| arr + (lam || blk).call(elt).to_a }
+        inject(self.class.empty) do |arr, elt|
+          res = (lam || blk).call(elt)
+          arr + (res.respond_to?(:to_a) ? res.to_a : [res])
+        end
       end
     end
   end

--- a/lib/rumonade/monad.rb
+++ b/lib/rumonade/monad.rb
@@ -55,8 +55,12 @@ module Rumonade
     #   [Some(Some(1)), Some(Some(None))], [None]].flatten
     #   #=> [1]
     #
-    def flatten_with_monad
-      bind { |x| x.is_a?(Monad) ? x.flatten_with_monad : self.class.unit(x) }
+    def flatten_with_monad(depth=nil)
+      if depth.is_a? Integer
+        depth.times.inject(self) {|e, _| e.shallow_flatten }
+      else
+        bind { |x| x.is_a?(Monad) ? x.flatten_with_monad : self.class.unit(x) }
+      end
     end
 
     # Returns a monad whose elements are all those elements of this monad for which the given predicate returned true
@@ -71,11 +75,9 @@ module Rumonade
     # with the native Ruby flatten calls (multiple-level flattening).
     #
     # @example
-    #   [Some(Some(1)), Some(Some(None))], [None]].shallow_flatten
-    #   #=> [Some(Some(1)), Some(Some(None)), None]
-    #   [Some(Some(1)), Some(Some(None)), None].shallow_flatten
-    #   #=> [Some(1), Some(None)]
-    #   [Some(1), Some(None)].shallow_flatten
+    #   [Some(Some(1)), Some(Some(None)), [None]].shallow_flatten
+    #   #=> [Some(1), Some(None), None]
+    #   [Some(1), Some(None), None].shallow_flatten
     #   #=> [1, None]
     #   [1, None].shallow_flatten
     #   #=> [1]

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -24,6 +24,7 @@ class ArrayTest < Test::Unit::TestCase
 
   def test_flat_map_behaves_correctly
     assert_equal ["FOO", "BAR"], ["foo", "bar"].flat_map { |s| [s.upcase] }
+    assert_equal [2, 4, 6], [1, 2, 3].flat_map { |i| i * 2 }
   end
 
   def test_map_behaves_correctly

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -35,11 +35,23 @@ class ArrayTest < Test::Unit::TestCase
     assert_equal [1], [None, Some(1)].shallow_flatten
     assert_equal [1, Some(2)], [None, Some(1), Some(Some(2))].shallow_flatten
     assert_equal [Some(Some(None))], [Some(Some(Some(None)))].shallow_flatten
+    assert_equal [Some(1), Some(None), None], [Some(Some(1)), Some(Some(None)), [None]].shallow_flatten
   end
 
   def test_flatten_behaves_correctly
     assert_equal [0, 1, 2, 3, 4], [0, [1], [[2]], [[[3]]], [[[[4]]]]].flatten
     assert_equal [1, 2], [None, Some(1), Some(Some(2))].flatten
     assert_equal [], [Some(Some(Some(None)))].flatten
+  end
+
+  def test_flatten_with_argument_behaves_correctly
+    assert_equal [0, 1, [2], [[3]], [[[4]]]], [0, [1], [[2]], [[[3]]], [[[[4]]]]].flatten(1)
+    assert_equal [0, 1, 2, [3], [[4]]], [0, [1], [[2]], [[[3]]], [[[[4]]]]].flatten(2)
+    assert_equal [0, 1, 2, 3, [4]], [0, [1], [[2]], [[[3]]], [[[[4]]]]].flatten(3)
+    assert_equal [0, 1, 2, 3, 4], [0, [1], [[2]], [[[3]]], [[[[4]]]]].flatten(4)
+    assert_equal [Some(Some(1)), Some(Some(None)), [None]], [Some(Some(1)), Some(Some(None)), [None]].flatten(0)
+    assert_equal [Some(1), Some(None), None], [Some(Some(1)), Some(Some(None)), [None]].flatten(1)
+    assert_equal [1, None], [Some(Some(1)), Some(Some(None)), [None]].flatten(2)
+    assert_equal [1], [Some(Some(1)), Some(Some(None)), [None]].flatten(3)
   end
 end


### PR DESCRIPTION
Right now the monkey patch on Array#flatten crashes code that tries to call flatten with a given depth. This pull request should implement it correctly.
It would be cool if you could release a new version with the patch in it :)

Thanks!
  Martin
