### PR TITLE
rumonade breaks flatten on arrays containing a hash (fix)

### DIFF
--- a/lib/rumonade/hash.rb
+++ b/lib/rumonade/hash.rb
@@ -27,9 +27,16 @@ module Rumonade
         Option(self[key])
       end
     end
+
+    module InstanceOverrides
+      def can_flatten_in_monad?
+        false
+      end
+    end
   end
 end
 
 Hash.send(:extend, Rumonade::HashExtensions::ClassMethods)
 Hash.send(:include, Rumonade::HashExtensions::InstanceMethods)
 Hash.send(:include, Rumonade::Monad)
+Hash.send(:include, Rumonade::HashExtensions::InstanceOverrides)

--- a/lib/rumonade/monad.rb
+++ b/lib/rumonade/monad.rb
@@ -60,7 +60,7 @@ module Rumonade
         depth.times.inject(self) {|e, _| e.shallow_flatten }
       else
         bind do |x|
-          if x.is_a?(Monad) && !x.is_a?(Hash)
+          if x.is_a?(Monad) && x.can_flatten_in_monad?
             x.flatten_with_monad
           else
             self.class.unit(x)
@@ -90,6 +90,12 @@ module Rumonade
     #
     def shallow_flatten
       bind { |x| x.is_a?(Monad) ? x : self.class.unit(x) }
+    end
+
+    # True if flatten should use flatten_with_monad on members (eg. elements of an array)
+    # Is overwritten in Hash.
+    def can_flatten_in_monad?
+      true
     end
   end
 end

--- a/lib/rumonade/monad.rb
+++ b/lib/rumonade/monad.rb
@@ -59,7 +59,13 @@ module Rumonade
       if depth.is_a? Integer
         depth.times.inject(self) {|e, _| e.shallow_flatten }
       else
-        bind { |x| x.is_a?(Monad) ? x.flatten_with_monad : self.class.unit(x) }
+        bind do |x|
+          if x.is_a?(Monad) && !x.is_a?(Hash)
+            x.flatten_with_monad
+          else
+            self.class.unit(x)
+          end
+        end
       end
     end
 

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -55,4 +55,9 @@ class ArrayTest < Test::Unit::TestCase
     assert_equal [1, None], [Some(Some(1)), Some(Some(None)), [None]].flatten(2)
     assert_equal [1], [Some(Some(1)), Some(Some(None)), [None]].flatten(3)
   end
+
+  def test_flatten_does_not_break_default_ruby_behaviour
+    arr = [ { 'thou' => 'shalt', 'not touch' => 'hashes' }, ', seriously!' ]
+    assert_equal arr, arr.flatten
+  end
 end


### PR DESCRIPTION
The following error occurs when rumonade is around:

```
2.0.0p195 :001 > require 'rumonade'
 => true 
2.0.0p195 :002 > [ {foo: 1}, 1, 'a' ].flatten
TypeError: no implicit conversion of Array into Hash
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/hash.rb:22:in `merge'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/hash.rb:22:in `block in bind'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/hash.rb:22:in `each'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/hash.rb:22:in `inject'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/hash.rb:22:in `bind'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/monad.rb:62:in `flatten_with_monad'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/monad.rb:62:in `block in flatten_with_monad'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/array.rb:21:in `call'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/array.rb:21:in `block in bind'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/array.rb:21:in `each'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/array.rb:21:in `inject'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/array.rb:21:in `bind'
    from /home/mvielsmaier/.rvm/gems/ruby-2.0.0-p195/gems/rumonade-0.4.2/lib/rumonade/monad.rb:62:in `flatten_with_monad'
    from (irb):2
    from /home/mvielsmaier/.rvm/rubies/ruby-2.0.0-p195/bin/irb:16:in `<main>'
```

without rumonade:

```
2.0.0p195 :001 > [ {foo: 1}, 1, 'a' ].flatten
 => [{:foo=>1}, 1, "a"] 
```

I created a test that demonstrates the problem and fixed it.
